### PR TITLE
Upgrade Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
         otp: [23, 24]
         elixir: ['1.12', '1.13', '1.14']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}
           otp-version: ${{matrix.otp}}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
           path: |
@@ -34,12 +34,12 @@ jobs:
         otp: [24]
         elixir: ['1.14']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}
           otp-version: ${{matrix.otp}}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: mix-cache # id to use in retrieve action
         with:
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        otp: [23, 24]
-        elixir: ['1.12', '1.13', '1.14']
+        otp: [24, 25]
+        elixir: ['1.13', '1.14']
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
This PR upgrades GH actions and versions of OTP and Elixir used in Github actions. It would appear that ubuntu-latest no longer supports OTP 23 or Elixir 1.12. This replaces unsupported versions with newer versions. 

Since this is a publicly released library, we may want to hold off an be more deliberate about supported versions. Or perhaps use a different ubuntu image that allows to continue to support older versions of OTP and Elixir. 

* cache@v3
* checkout@v3