### PR TITLE
Support implicit `count` with opts

### DIFF
--- a/lib/endon.ex
+++ b/lib/endon.ex
@@ -266,7 +266,10 @@ defmodule Endon do
       @spec first(integer(), keyword()) :: [Ecto.Schema.t()] | Ecto.Schema.t() | nil
       def first(count \\ 1, opts \\ [])
 
-      def first(count, opts),
+      def first(count, opts) when not is_integer(count), do: do_first(1, count)
+      def first(count, opts) , do: do_first(count, opts)
+
+      defp do_first(count, opts),
         do: Helpers.first(@repo, __MODULE__, count, opts)
 
       @doc """
@@ -302,7 +305,10 @@ defmodule Endon do
       @spec last(integer(), keyword()) :: [Ecto.Schema.t()] | Ecto.Schema.t() | nil
       def last(count \\ 1, opts \\ [])
 
-      def last(count, opts),
+      def last(count, opts) when not is_integer(count), do: do_last(1, count)
+      def last(count, opts), do: do_last(1, count)
+
+      defp do_last(count, opts),
         do: Helpers.last(@repo, __MODULE__, count, opts)
 
       @doc """

--- a/test/endon_test.exs
+++ b/test/endon_test.exs
@@ -164,6 +164,36 @@ defmodule EndonTest do
       refute UserNone.exists?(one: 1)
       assert UserSingle.exists?(one: 1)
     end
+
+    test "when using first with a count" do
+      assert UserSingle.first(42) == ["from u0 in UserSingle, order_by: [asc: u0.id], limit: ^42"]
+    end
+
+    test "when using first with a count and order_by" do
+      assert UserSingle.first(42, order_by: :info) == [
+               "from u0 in UserSingle, order_by: [asc: u0.info], limit: ^42"
+             ]
+    end
+
+    test "when using first with no count and order_by" do
+      assert UserSingle.first(order_by: :info) ==
+               "from u0 in UserSingle, order_by: [asc: u0.info], limit: ^1"
+    end
+
+    test "when using last with a count" do
+      assert UserSingle.last(42) == ["from u0 in UserSingle, order_by: [desc: u0.id], limit: ^42"]
+    end
+
+    test "when using last with a count and order_by" do
+      assert UserSingle.last(42, order_by: :info) == [
+               "from u0 in UserSingle, order_by: [desc: u0.info], limit: ^42"
+             ]
+    end
+
+    test "when using last with no count and order_by" do
+      assert UserSingle.last(order_by: :info) ==
+               "from u0 in UserSingle, order_by: [desc: u0.info], limit: ^1"
+    end
   end
 
   describe "updating records should work" do


### PR DESCRIPTION
`first/2` and `last/2` can be called with unexpected args, e.g., `UserSingle.first(order_by: :info)`. Once might expect that to return the 1st record ordered by info ascending. Instead, it returns a query like "from u0 in UserSingle, order_by: [asc: u0.id], limit: ^[{:order_by, :info}]". Should we consider checking to see if count is an integer and defaulting it to 1 if it's not?