### PR TITLE
Support row level locking in select queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
-  * Add support for the `:limit` option (#8)
+  * Add support for the `:lock` option (#8)
 
 ## v2.0.0 (2023-08-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v2.0.1 (2023-08-11)
+
+### Enhancements
+
+  * Add support for the `:limit` option (#8)
+
 ## v2.0.0 (2023-08-01)
 
 ### Breaking Changes

--- a/lib/endon.ex
+++ b/lib/endon.ex
@@ -168,7 +168,7 @@ defmodule Endon do
       ## Options
 
         * `:preload` - A list of fields to preload, much like `c:Ecto.Repo.preload/3`
-
+        * `:lock` - Row level lock in the select. Currently only `:for_update` is supported.
       """
       @spec fetch(integer() | list(integer()), keyword()) ::
               {:ok, list(Ecto.Schema.t())} | {:ok, Ecto.Schema.t()} | :error
@@ -198,8 +198,8 @@ defmodule Endon do
 
       ## Options
 
-        * `:preload` - A list of fields to preload, much like `c:Ecto.Repo.preload/3`
-
+       * `:preload` - A list of fields to preload, much like `c:Ecto.Repo.preload/3`
+       * `:lock` - Row level lock in the select. Currently only `:for_update` is supported.
       """
       @spec find(integer() | list(integer()), keyword()) ::
               list(Ecto.Schema.t()) | Ecto.Schema.t()
@@ -214,7 +214,7 @@ defmodule Endon do
       ## Options
 
         * `:preload` - A list of fields to preload, much like `c:Ecto.Repo.preload/3`
-
+        * `:lock` - Row level lock in the select. Currently only `:for_update` is supported.
       """
       @spec find_by(where_conditions(), keyword()) :: Ecto.Schema.t() | nil
       def find_by(conditions, opts \\ []),
@@ -417,6 +417,7 @@ defmodule Endon do
         * `:preload` - A list of fields to preload, much like `c:Ecto.Repo.preload/3`
         * `:offset` - Number to offset by
         * `:limit` - Limit results to the given count
+        * `:lock` - Row level lock in the select. Currently only `:for_update` is supported.
 
       ## Examples
 

--- a/lib/endon/helpers.ex
+++ b/lib/endon/helpers.ex
@@ -97,7 +97,7 @@ defmodule Endon.Helpers do
   def find_by(repo, module, conditions, opts) do
     module
     |> add_where(conditions)
-    |> add_opts([limit: 1] ++ opts, [:limit, :preload])
+    |> add_opts([limit: 1] ++ opts, [:limit, :preload, :lock])
     |> repo.one()
   end
 

--- a/lib/endon/helpers.ex
+++ b/lib/endon/helpers.ex
@@ -104,7 +104,7 @@ defmodule Endon.Helpers do
   def where(repo, module, conditions, opts) do
     module
     |> add_where(conditions)
-    |> add_opts(opts, [:limit, :order_by, :offset, :preload])
+    |> add_opts(opts, [:limit, :order_by, :offset, :preload, :lock])
     |> repo.all()
   end
 
@@ -269,6 +269,8 @@ defmodule Endon.Helpers do
   defp apply_opt(query, :limit, limit), do: Query.limit(query, ^limit)
   defp apply_opt(query, :preload, preload), do: Query.preload(query, ^preload)
   defp apply_opt(query, :offset, offset), do: Query.offset(query, ^offset)
+  # for security reasons, locks must always be literal strings
+  defp apply_opt(query, :lock, :for_update), do: Query.lock(query, "FOR UPDATE")
 
   defp add_where(query, []), do: query
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Endon.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/parallel-markets/endon"
-  @version "2.0.0"
+  @version "2.0.1"
 
   def project do
     [

--- a/test/endon_test.exs
+++ b/test/endon_test.exs
@@ -113,7 +113,9 @@ defmodule EndonTest do
     end
 
     test "when using where with a limit" do
-      assert UserSingle.where([id: 1], lock: :for_update) == ["from u0 in UserSingle, where: u0.id == ^1, lock: \"FOR UPDATE\""]
+      assert UserSingle.where([id: 1], lock: :for_update) == [
+               "from u0 in UserSingle, where: u0.id == ^1, lock: \"FOR UPDATE\""
+             ]
     end
 
     test "when using where with a map" do

--- a/test/endon_test.exs
+++ b/test/endon_test.exs
@@ -123,8 +123,8 @@ defmodule EndonTest do
     end
 
     test "when using where with limit keyword" do
-      assert UserSingle.where(id: 1, limit: 2) == [
-               "from u0 in UserSingle, where: u0.id == ^1, where: u0.limit == ^2"
+      assert UserSingle.where([id: 1], limit: 2) == [
+               "from u0 in UserSingle, where: u0.id == ^1, limit: ^2"
              ]
     end
 

--- a/test/endon_test.exs
+++ b/test/endon_test.exs
@@ -112,6 +112,10 @@ defmodule EndonTest do
       assert UserSingle.where(id: 1) == ["from u0 in UserSingle, where: u0.id == ^1"]
     end
 
+    test "when using where with a limit" do
+      assert UserSingle.where([id: 1], lock: :for_update) == ["from u0 in UserSingle, where: u0.id == ^1, lock: \"FOR UPDATE\""]
+    end
+
     test "when using where with a map" do
       assert UserSingle.where(%{id: 1}) == ["from u0 in UserSingle, where: u0.id == ^1"]
     end


### PR DESCRIPTION
This PR adds support for the `:lock` option to a number of the functions that produce `SELECT` queries.  Currently, only `:for_update` is supported.