### PR TITLE
Upgrade GHA, add elixir 1.15 to test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ jobs:
     strategy:
       matrix:
         otp: [24, 25]
-        elixir: ['1.13', '1.14']
+        elixir: ["1.13", "1.14", "1.15"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         otp: [24]
-        elixir: ['1.14']
+        elixir: ["1.14"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         otp: [24]
-        elixir: ["1.14"]
+        elixir: ["1.15"]
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1


### PR DESCRIPTION
This PR:
* upgrades GHA checkout action to newest version, 
* adds elixir 1.15 to the test matrix,
* upgrades dialyzer elixir runtime to 1.15

Autoformatter changed some quotes, i hope its not a problem, but if it is, i can manually fix it. 