### PR TITLE
Run CI for Elixir 1.16, update cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ jobs:
     strategy:
       matrix:
         otp: [24, 25]
-        elixir: ["1.13", "1.14", "1.15"]
+        elixir: ["1.13", "1.14", "1.15", "1.16"]
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{matrix.elixir}}
           otp-version: ${{matrix.otp}}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: mix-cache # id to use in retrieve action
         with:
           path: |
@@ -39,7 +39,7 @@ jobs:
         with:
           elixir-version: ${{matrix.elixir}}
           otp-version: ${{matrix.otp}}
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         id: mix-cache # id to use in retrieve action
         with:
           path: |


### PR DESCRIPTION
This PR adds elixir 1.16 to the CI build and bumps `cache` action to v4.


Its possible that dialyzer also could be run on 1.16, but i think last time i had troubles upgrading OTP on that task, so this time im playing safe.